### PR TITLE
Fix default timeout in browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "promise": "^6.0.0",
     "request": "^2.44.0",
-    "xhr": "^1.16.1"
+    "xhr": "^2.1.0"
   },
   "testling": {
     "files": [


### PR DESCRIPTION
The following code succeeds in Node, but fails when browserified and run in a browser.

```javascript
require('httpify')('https://httpbin.org/delay/6').then(console.log.bind(console), console.error.bind(console))
```

This is due to `xhr` having a [default `timeout` option value of 5000](https://github.com/Raynos/xhr/blob/v1.17.1/index.js#L69). The default timeout was [changed](https://github.com/Raynos/xhr/commit/5714cde39f9d48e4bd669bb76812782a1e213b84#diff-168726dbe96b3ce427e7fedce31bb0bcL61) to 0 in `xhr` version 2.0.0 and up, so this change simply uses `xhr@^2.1.0` to make the browser behave the same as Node.